### PR TITLE
Adding test case for deploying node using tempest

### DIFF
--- a/ironic_tempest_plugin/tests/scenario/ironic_standalone/test_basic_ops.py
+++ b/ironic_tempest_plugin/tests/scenario/ironic_standalone/test_basic_ops.py
@@ -16,7 +16,8 @@
 from tempest.common import utils
 from tempest import config
 from tempest.lib import decorators
-
+from ironic_tempest_plugin.common import utils \
+        as uls
 from ironic_tempest_plugin.tests.scenario import \
     baremetal_standalone_manager as bsm
 
@@ -70,7 +71,7 @@ class BaremetalAgentIpmitoolPartitioned(bsm.BaremetalStandaloneScenarioTest):
 
 class BaremetalPxeIpmitoolWholedisk(bsm.BaremetalStandaloneScenarioTest):
 
-    driver = 'pxe_ipmitool'
+    driver = 'idrac'
     image_ref = CONF.baremetal.whole_disk_image_ref
     wholedisk_image = True
 
@@ -83,7 +84,7 @@ class BaremetalPxeIpmitoolWholedisk(bsm.BaremetalStandaloneScenarioTest):
 class BaremetalPxeIpmitoolWholediskHttpLink(
         bsm.BaremetalStandaloneScenarioTest):
 
-    driver = 'pxe_ipmitool'
+    driver = 'idrac'
     image_ref = CONF.baremetal.whole_disk_image_url
     image_checksum = CONF.baremetal.whole_disk_image_checksum
     wholedisk_image = True
@@ -149,15 +150,57 @@ class BaremetalDriverDirectWholedisk(bsm.BaremetalStandaloneScenarioTest):
     image_ref = CONF.baremetal.whole_disk_image_ref
     wholedisk_image = True
 
-    @classmethod
-    def skip_checks(cls):
-        super(BaremetalDriverDirectWholedisk, cls).skip_checks()
-        if cls.driver == 'ipmi':
-            skip_msg = ("Test covered when using redfish")
-            raise cls.skipException(skip_msg)
+   # @classmethod
+   # def skip_checks(cls):
+   #     super(BaremetalDriverDirectWholedisk, cls).skip_checks()
+   #     if cls.driver == 'ipmi':
+   #         skip_msg = ("Test covered when using redfish")
+   #         raise cls.skipException(skip_msg)
 
     @decorators.idempotent_id('c2db24e7-07dc-4a20-8f93-d4efae2bfd4e')
     @utils.services('image', 'network')
+    def test_ip_access_to_server(self):
+        self.boot_and_verify_node()
+
+
+class BaremetalIdracDriverDirect(bsm.BaremetalStandaloneScenarioTest):
+
+    api_microversion = '1.31'  # to set the deploy_interface
+    driver = 'idrac'
+    deploy_interface = 'direct'
+    image_ref = CONF.baremetal.whole_disk_image_ref
+    wholedisk_image = True
+
+    @utils.services('image', 'network')
+    @decorators.idempotent_id('c2bebda2-fd27-4b10-9015-f7d877f0eb60')
+    def test_ip_access_to_server(self):
+        self.boot_and_verify_node()
+
+
+class BaremetalRedfishDriverDirect(bsm.BaremetalStandaloneScenarioTest):
+
+    api_microversion = '1.31'  # to set the deploy_interface
+    driver = 'redfish'
+    deploy_interface = 'direct'
+    image_ref = CONF.baremetal.whole_disk_image_ref
+    wholedisk_image = True
+
+    @utils.services('image', 'network')
+    @decorators.idempotent_id('dde74f6a-15a6-40c1-bfd5-eab54252ed56')
+    def test_ip_access_to_server(self):
+        self.boot_and_verify_node()
+
+
+class BaremetalIpmiDriverDirect(bsm.BaremetalStandaloneScenarioTest):
+
+    api_microversion = '1.31'  # to set the deploy_interface
+    driver = 'ipmi'
+    deploy_interface = 'direct'
+    image_ref = CONF.baremetal.whole_disk_image_ref
+    wholedisk_image = True
+
+    @utils.services('image', 'network')
+    @decorators.idempotent_id('21036e6b-8d77-4e54-bb71-c7f80998ab0d')
     def test_ip_access_to_server(self):
         self.boot_and_verify_node()
 
@@ -436,3 +479,4 @@ class BaremetalRedfishIPxeWholediskHttpLink(
     @utils.services('network')
     def test_ip_access_to_server(self):
         self.boot_and_verify_node()
+


### PR DESCRIPTION
This test case can be used for deployment of node using iPXE boot and types of drivers i.e idrac-wsman, idrac-redfish, IPMI and redfish.